### PR TITLE
Add encrypt_at_time and decrypt_at_time with warnings and documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2018"
 [badges]
 travis-ci = { repository = "mozilla-services/fernet-rs" }
 
+[features]
+fernet_danger_timestamps = []
+
 [dependencies]
 base64 = "0.10"
 byteorder = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fernet"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Alex Gaynor <agaynor@mozilla.com>", "Ben Bangert <bbangert@mozilla.com>"]
 description = "An implementation of fernet in Rust."
 repository = "https://github.com/mozilla-services/fernet-rs/"


### PR DESCRIPTION
This allows external applications to test and develop their applications where time can be passed in as a state parameter, rather than just using the fernet methods that assume time. This is important for applications that want to test correct behaviour of their own libraries that depend on fernet for token expiry. 