### PR TITLE
#17 provide improvements to documentation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,15 @@ license = "MPL-2.0"
 readme = "README.md"
 edition = "2018"
 
+
 [badges]
 travis-ci = { repository = "mozilla-services/fernet-rs" }
 
 [features]
 fernet_danger_timestamps = []
+
+[package.metadata.docs.rs]
+features = [ "fernet_danger_timestamps" ]
 
 [dependencies]
 base64 = "0.10"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,51 @@
-# fernet-rs
+fernet-rs
+=========
 
 [![dependency status](https://deps.rs/repo/github/mozilla-services/fernet-rs/status.svg)](https://deps.rs/repo/github/mozilla-services/fernet-rs)
 
 An implementation of [fernet](https://github.com/fernet/spec) in Rust.
+
+What is Fernet?
+---------------
+
+Fernet is a small library to help you encrypt parcels of data with optional expiry times. It's
+great for tokens or exchanging small strings or blobs of data. Fernet is designed to be easy
+to use, combining cryptographic primitives in a way that is hard to get wrong, prevents tampering
+and gives you confidence that the token is legitimate. You should consider this if you need:
+
+* Time limited authentication tokens in URLs or authorisation headers
+* To send small blobs of encrypted data between two points with a static key
+* Simple encryption of secrets to store to disk that can be read later
+* Many more ...
+
+Great! How do I start?
+----------------------
+
+Add fernet to your Cargo.toml:
+
+    [dependencies]
+    fernet = "0.1"
+
+And then have a look at our [API documentation] online, or run "cargo doc --open" in your
+project.
+
+[API documentation online]: https://docs.rs/fernet
+
+Testing Token Expiry
+--------------------
+
+By default fernet wraps operations in an attempt to be safe - you should never be able to
+"hold it incorrectly". But we understand that sometimes you need to be able to do some
+more complicated operations.
+
+The major example of this is having your application test how it handles tokens that
+have expired past their ttl.
+
+To support this, we allow you to pass in timestamps to the `encrypt_at_time` and
+`decrypt_at_time` functions, but these are behind a feature gate. To activate these
+api's you need to add the following to Cargo.toml
+
+    [dependencies]
+    fernet = { version = "0.1", features = "fernet_danger_timestamps" }
+
+


### PR DESCRIPTION
I'm not 100% sure on what improvements you "had in mind" but at the very least, this improves the README.md which will be displayed on github + crates.io with more details, and adds some extra details around some specific functions. We could consider throwing in some example code and usage into docs.

I'm also currently investigating how to have the "fernet_danger_timestamps" feature documented on docs.rs but without it being enabled by default. 