### PR TITLE
Derive Clone for Fernet, impl Error for DecryptionError, and fix Rust 2018 issues

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ use std::time;
 
 const MAX_CLOCK_SKEW: u64 = 60;
 
+#[derive(Clone)]
 pub struct Fernet {
     encryption_key: [u8; 16],
     signing_key: [u8; 16],
@@ -33,6 +34,7 @@ pub struct Fernet {
 #[derive(Debug, PartialEq, Eq)]
 pub struct DecryptionError;
 
+#[derive(Clone)]
 pub struct MultiFernet {
     fernets: Vec<Fernet>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@
 // ```
 
 use byteorder::ReadBytesExt;
+use std::error::Error;
+use std::fmt::{self, Display};
 use std::io::{Cursor, Read};
 use std::time;
 
@@ -33,6 +35,14 @@ pub struct Fernet {
 /// invalid.
 #[derive(Debug, PartialEq, Eq)]
 pub struct DecryptionError;
+
+impl Error for DecryptionError {}
+
+impl Display for DecryptionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Fernet decryption error")
+    }
+}
 
 #[derive(Clone)]
 pub struct MultiFernet {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,7 @@
 //! assert_eq!(decrypted_plaintext.unwrap(), plaintext);
 // ```
 
-use base64;
 use byteorder::ReadBytesExt;
-use getrandom;
-use openssl;
 use std::io::{Cursor, Read};
 use std::time;
 
@@ -182,7 +179,7 @@ impl Fernet {
             .duration_since(time::UNIX_EPOCH)
             .unwrap()
             .as_secs();
-        return self._decrypt_at_time(token, Some(ttl_secs), current_time);
+        self._decrypt_at_time(token, Some(ttl_secs), current_time)
     }
 
     /// Decrypt a ciphertext with a time-to-live, and the current time.
@@ -277,10 +274,7 @@ impl Fernet {
 #[cfg(test)]
 mod tests {
     use super::{DecryptionError, Fernet, MultiFernet};
-    use base64;
-    use chrono;
     use serde_derive::Deserialize;
-    use serde_json;
     use std::collections::HashSet;
 
     #[derive(Deserialize)]


### PR DESCRIPTION
- Clone is derived for `Fernet` and `MultiFernet`
- `Error` and `Display` (required by `Error`) are implemented for `DecryptionError`
- Rust 2018 clippy warnings/errors are fixed