### PR TITLE
Add rustcrypto option to use pure-rust crypto

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
           - stable
           - beta
           - nightly
+        features:
+          - "--features default"
+          - "--no-default-features --features rustcrypto"
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions-rs/toolchain@v1                                                                                      
@@ -23,10 +26,16 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
+          args: ${{ matrix.features }}
 
       - uses: actions-rs/cargo@v1
         with:
           command: test
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: ${{ matrix.features }}
 
       - uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ subtle = { version = "2.4", optional = true }
 
 
 [dev-dependencies]
-chrono = "0.4"
+time = { version = "0.3", features = ["parsing"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ openssl = { version = "0.10", optional = true }
 getrandom = "0.2"
 zeroize = { version = "1.0", features = ["zeroize_derive"] }
 aes = { version = "0.8", optional = true }
-cbc = { version = "0.1", optional = true }
+cbc = { version = "0.1", optional = true, features = ["alloc"] }
 hmac = { version = "0.12", optional = true }
 sha2 = { version = "0.10", optional = true }
 subtle = { version = "2.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,17 +14,25 @@ edition = "2018"
 travis-ci = { repository = "mozilla-services/fernet-rs" }
 
 [features]
+default = ["openssl"]
 fernet_danger_timestamps = []
+rustcrypto = ["aes", "cbc", "sha2", "hmac", "subtle"]
 
 [package.metadata.docs.rs]
-features = [ "fernet_danger_timestamps" ]
+features = ["fernet_danger_timestamps"]
 
 [dependencies]
 base64 = "0.13"
 byteorder = "1"
-openssl = "0.10"
+openssl = { version = "0.10", optional = true }
 getrandom = "0.2"
 zeroize = { version = "1.0", features = ["zeroize_derive"] }
+aes = { version = "0.8", optional = true }
+cbc = { version = "0.1", optional = true }
+hmac = { version = "0.12", optional = true }
+sha2 = { version = "0.10", optional = true }
+subtle = { version = "2.4", optional = true }
+
 
 [dev-dependencies]
 chrono = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,12 @@ use hmac::Mac;
 #[cfg(feature = "rustcrypto")]
 use sha2::Sha256;
 
+#[cfg(not(any(feature = "rustcrypto", feature = "default",)))]
+compile_error!(
+    "no crypto cargo feature enabled! \
+     please enable one of: default, rustcrypto"
+);
+
 const MAX_CLOCK_SKEW: u64 = 60;
 
 // Automatically zero out the contents of the memory when the struct is drop'd.
@@ -476,7 +482,7 @@ mod tests {
         assert_eq!(
             f.decrypt(&base64::encode_config(
                 b"\x80\x00\x00\x00",
-                base64::URL_SAFE
+                base64::URL_SAFE,
             )),
             Err(DecryptionError)
         );
@@ -580,7 +586,7 @@ mod tests {
             f._decrypt_at_time(
                 &f._encrypt_at_time(b"abc", current_time),
                 Some(30),
-                good_time
+                good_time,
             )
             .unwrap(),
             b"abc".to_vec()
@@ -589,7 +595,7 @@ mod tests {
             f._decrypt_at_time(
                 &f._encrypt_at_time(b"abc", current_time),
                 Some(30),
-                exp_time
+                exp_time,
             )
             .unwrap_err(),
             DecryptionError

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,11 +292,11 @@ impl Fernet {
         let ciphertext = &rest[..rest.len() - 32];
         let hmac = &rest[rest.len() - 32..];
 
-        let mut mac = Hmac::<Sha256>::new_from_slice(&self.signing_key)
+        let mut hmac_signer = Hmac::<Sha256>::new_from_slice(&self.signing_key)
             .expect("Signing key has unexpected size");
-        mac.update(&data.get_ref()[..data.get_ref().len() - 32]);
+        hmac_signer.update(&data.get_ref()[..data.get_ref().len() - 32]);
 
-        let expected_hmac = mac.finalize().into_bytes();
+        let expected_hmac = hmac_signer.finalize().into_bytes();
 
         use subtle::ConstantTimeEq;
         if hmac.ct_eq(&expected_hmac).unwrap_u8() == 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,10 @@ use hmac::Mac;
 #[cfg(feature = "rustcrypto")]
 use sha2::Sha256;
 
-#[cfg(not(any(feature = "rustcrypto", feature = "default",)))]
+#[cfg(not(any(feature = "rustcrypto", feature = "openssl",)))]
 compile_error!(
     "no crypto cargo feature enabled! \
-     please enable one of: default, rustcrypto"
+     please enable one of: default, openssl"
 );
 
 const MAX_CLOCK_SKEW: u64 = 60;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,7 +299,8 @@ impl Fernet {
         let expected_hmac = hmac_signer.finalize().into_bytes();
 
         use subtle::ConstantTimeEq;
-        if hmac.ct_eq(&expected_hmac).unwrap_u8() == 0 {
+        let hmac_matches: bool = hmac.ct_eq(&expected_hmac).into();
+        if !hmac_matches {
             return Err(DecryptionError);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,6 +360,8 @@ mod tests {
     use super::{DecryptionError, Fernet, MultiFernet};
     use serde_derive::Deserialize;
     use std::collections::HashSet;
+    use time::format_description::well_known::Rfc3339;
+    use time::OffsetDateTime;
 
     #[derive(Deserialize)]
     struct GenerateVector<'a> {
@@ -396,9 +398,9 @@ mod tests {
             let f = Fernet::new(v.secret).unwrap();
             let token = f._encrypt_from_parts(
                 v.src.as_bytes(),
-                chrono::DateTime::parse_from_rfc3339(v.now)
+                OffsetDateTime::parse(v.now, &Rfc3339)
                     .unwrap()
-                    .timestamp() as u64,
+                    .unix_timestamp() as u64,
                 &v.iv,
             );
             assert_eq!(token, v.token);
@@ -415,9 +417,9 @@ mod tests {
             let decrypted = f._decrypt_at_time(
                 v.token,
                 Some(v.ttl_sec),
-                chrono::DateTime::parse_from_rfc3339(v.now)
+                OffsetDateTime::parse(v.now, &Rfc3339)
                     .unwrap()
-                    .timestamp() as u64,
+                    .unix_timestamp() as u64,
             );
             assert_eq!(decrypted, Ok(v.src.as_bytes().to_vec()));
         }
@@ -433,9 +435,9 @@ mod tests {
             let decrypted = f._decrypt_at_time(
                 v.token,
                 Some(v.ttl_sec),
-                chrono::DateTime::parse_from_rfc3339(v.now)
+                OffsetDateTime::parse(v.now, &Rfc3339)
                     .unwrap()
-                    .timestamp() as u64,
+                    .unix_timestamp() as u64,
             );
             assert_eq!(decrypted, Err(DecryptionError));
         }


### PR DESCRIPTION
Hi! I was trying to cross-compile my project to arm64, and the only hurdle left was openssl dependency. I managed to move all dependencies away from it from everything except fernet-rs, so I thought I'd add that as an option.
So adding `default-features = false, features = ["rustcrypto"]` should make it compile with musl.

* Added a test in github actions for both with and without the feature flag.
* Also had to switch from chrono to time to get cargo audit check green.

Tested with a simple Dockerfile:
```
FROM rust:latest
RUN rustup target add x86_64-unknown-linux-musl
RUN apt update && apt install -y musl-tools musl-dev
RUN update-ca-certificates
ADD . .
RUN cargo build --release --target x86_64-unknown-linux-musl --no-default-features --features rustcrypto
```

And for cross-compiling
```
FROM rust:latest
RUN apt update && apt install -y musl-tools musl-dev
RUN apt install -y gcc make gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
RUN rustup target add aarch64-unknown-linux-musl
RUN update-ca-certificates
ADD . .
RUN cargo build --release --target aarch64-unknown-linux-musl --no-default-features --features rustcrypto
```