### PR TITLE
release: 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fernet"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["Alex Gaynor <agaynor@mozilla.com>", "Ben Bangert <bbangert@mozilla.com>"]
 description = "An implementation of fernet in Rust."
 repository = "https://github.com/mozilla-services/fernet-rs/"


### PR DESCRIPTION
 Feature: Add `rustcrypto` option to use pure-rust crypto (thanks: @henrikno) ([e8194fa3](https://github.com/mozilla-services/fernet-rs/commit/e8194fa33e06c1c5638ac9248c3b08f4625429ee))